### PR TITLE
Update the Jenkins Core baseline to 2.138.4 to avoid implied dependencies on the JDK Tool plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.29</version>
+    <version>3.45</version>
   </parent>
   
   <artifactId>label-verifier</artifactId>
@@ -14,8 +14,8 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Label+Verifier+Plugin</url>
 
   <properties>
-    <jenkins.version>1.651.3</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.138.4</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <licenses>


### PR DESCRIPTION
I have the plugin installed on my instance, but I do not want to have Oracle JDK Tool plugin there as an installed one: https://plugins.jenkins.io/jdk-tool. So I want to bump the dependency of the core beyond 2.112 where it was detached.

CC @jenkinsci/java11-support 