### PR TITLE
Add missing index Jelly to the plugin

### DIFF
--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+  This plugin allows system administrator to programmatically verify the label assignment correctness on agents
+</div>


### PR DESCRIPTION
Currently the information is being pulled from Jenkins Wiki.
It would be nice to have explicit documentation so that the update center can use the plugin metadata