### PR TITLE
Updated parent POM to 4.76

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.45</version>
+    <version>4.76</version>
   </parent>
   
   <artifactId>label-verifier</artifactId>
@@ -14,7 +14,7 @@
   <url>https://github.com/jenkinsci/label-verifier-plugin</url>
 
   <properties>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.414.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
 


### PR DESCRIPTION
Allows it to compile on java 17 and 21

Updated Jenkins version to 2.414.3

Allows Jenkins to keep up to date

Fixed first line in POM

Calls the right commands to make the POM complete