### PR TITLE
Plugin name does not need 'plugin' in the name string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>label-verifier</artifactId>
   <version>${changelist}</version>
   <packaging>hpi</packaging>
-  <name>Label verifier plugin</name>
+  <name>Label Verifier</name>
   <url>https://github.com/${gitHubRepo}</url>
 
   <licenses>


### PR DESCRIPTION
## Plugin name does not need 'plugin' in the name string

[Plugin publishing style guide](https://www.jenkins.io/doc/developer/publishing/style-guides/) recommends that the word 'plugin' is not helpful in the name of a plugin.

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
